### PR TITLE
Update maxreplicas to 4

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -21,7 +21,7 @@ healthProbes:
   readinessPeriod: 10
 
 minReplicaCount: 2
-maxReplicaCount: 2
+maxReplicaCount: 4
 
 resources:
   requests:


### PR DESCRIPTION
Scaling is stuck for most deployments via the static helm chart. It makes sense to set the max replicas higher so they can scale with load. TBD is to tune the requests and limits.