### PR TITLE
Add hosttls option to allow generating tls cert for hostnames

### DIFF
--- a/templates/nginx-ingress.yaml
+++ b/templates/nginx-ingress.yaml
@@ -17,6 +17,9 @@ spec:
   tls:
   - hosts:
     - {{ .Values.hostname }}
+    {{- if .Values.hosttls }}
+    secretName: {{ .Values.hostname }}
+    {{- end }}
   {{- if .Values.nginxingress.hosts }}
   {{- range .Values.nginxingress.hosts }}
   - hosts:

--- a/values.yaml
+++ b/values.yaml
@@ -3,6 +3,7 @@ environment: production
 
 hostname: www.example.org
 hostpath: ""
+hosttls: false
 
 image:
   repository: gcr.io/planet-4-151612/openresty


### PR DESCRIPTION
This allows cert-manager to generate TLS certificates for the 'hostname' value in the values to yaml - the "primary" host for the server. Currently it isn't possible to generate certs with cert-manager for these values in the static helm chart as there is not secretName field set.

This adds a new parameter hosttls that is disabled by default to optionally add a secretName field which will allow cert-manager to grab a certificate as required.